### PR TITLE
Sets adapter only when not set already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Adds `QueueBus.has_adapter?` to check whether the adapter is set before setting it to resque. This will allow multiple adapters to be loaded without error.
+
+### Changed
+- Bump version dependency of queue-bus to at least 0.7

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
 
 gem "rake"
-# gem "queue-bus", path: "../queue-bus"

--- a/lib/resque-bus.rb
+++ b/lib/resque-bus.rb
@@ -16,4 +16,4 @@ module ResqueBus
   extend ::ResqueBus::Deprecated
 end
 
-QueueBus.adapter = QueueBus::Adapters::Resque.new
+QueueBus.adapter = QueueBus::Adapters::Resque.new unless QueueBus.has_adapter?

--- a/lib/resque-bus.rb
+++ b/lib/resque-bus.rb
@@ -16,4 +16,9 @@ module ResqueBus
   extend ::ResqueBus::Deprecated
 end
 
-QueueBus.adapter = QueueBus::Adapters::Resque.new unless QueueBus.has_adapter?
+if QueueBus.has_adapter?
+  warn '[ResqueBus] Not setting adapter on queue-bus because ' \
+      "#{QueueBus.adapter.class.name} is already the adapter"
+else
+  QueueBus.adapter = QueueBus::Adapters::Resque.new
+end

--- a/resque-bus.gemspec
+++ b/resque-bus.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('queue-bus', ['>= 0.5.9', '< 1'])
+  s.add_dependency('queue-bus', ['>= 0.7', '< 1'])
   s.add_dependency('resque', ['>= 1.10.0', '< 2.0'])
   s.add_dependency('resque-scheduler', '>= 2.0.1')
   s.add_dependency('resque-retry')


### PR DESCRIPTION
This change requires that a new version of queue-bus be used and so
changes the dependency as well. It also adds a changelog file to track
changes in.